### PR TITLE
Got rid of deprecated rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [9.1.0] - 2023-07-04
+
+Got rid of deprecated rules
+
+### Removed
+
+- [`jsx-a11y/accessible-emoji`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/accessible-emoji.md).
+- [`jsx-a11y/no-onchange`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-onchange.md).
+
+### Changed
+
+- [`react/jsx-sort-default-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-default-props.md) replaced by [`react/sort-default-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/sort-default-props.md).
+
 ## [9.0.1] - 2023-06-30
 
 Technical release which is required to overwrite the contents of the tag `latest`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bluedrop",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bluedrop",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Bluedrop's ESLint configurations",
   "main": "config/common.js",
   "bin": {

--- a/rules/plugin-jsx-a11y.js
+++ b/rules/plugin-jsx-a11y.js
@@ -4,7 +4,6 @@
 
 module.exports = {
 	rules: {
-		'jsx-a11y/accessible-emoji': 'error',
 		'jsx-a11y/alt-text': 'error',
 		'jsx-a11y/anchor-has-content': 'error',
 		'jsx-a11y/anchor-is-valid': 'error',
@@ -80,7 +79,6 @@ module.exports = {
 		],
 		'jsx-a11y/no-noninteractive-element-to-interactive-role': 'error',
 		'jsx-a11y/no-noninteractive-tabindex': 'error',
-		'jsx-a11y/no-onchange': 'error',
 		'jsx-a11y/no-redundant-roles': 'error',
 		'jsx-a11y/no-static-element-interactions': 'error',
 		'jsx-a11y/role-has-required-aria-props': 'error',

--- a/rules/plugin-react.js
+++ b/rules/plugin-react.js
@@ -119,7 +119,7 @@ module.exports = {
 		}],
 		'react/jsx-props-no-multi-spaces': 'error',
 		'react/jsx-props-no-spreading': 'off',
-		'react/jsx-sort-default-props': [
+		'react/sort-default-props': [
 			'error',
 			{
 				ignoreCase: true,


### PR DESCRIPTION
## Description

### Removed

- [`jsx-a11y/accessible-emoji`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/accessible-emoji.md).
- [`jsx-a11y/no-onchange`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-onchange.md).

### Changed

- [`react/jsx-sort-default-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-default-props.md) replaced by [`react/sort-default-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/sort-default-props.md).

## Checklist

- [ ] I have tested this PR locally or on a remote environment.
- [ ] I have checked my code and corrected any misspellings.
- [ ] No dependent changes are required to be merged or published
